### PR TITLE
Separate Niivue interactions and mock testing

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -12,18 +12,20 @@ pnpm i
 
 ## Code Organization
 
-- `model.ts`: defines types
+- `model.ts`: type definitions.
 - `diff.ts`: helper functions for doing reconciliation from actual state to desired state.
   It's somewhat analogous to React's internal "diff" algorithm which updates the virtual DOM.
   Here, we do a diff between objects to compute which mutable setter functions of Niivue to call,
   which in turn update the canvas. As a programming habit, the functions of `diff.ts` are pure functions.
 - `diff.test.ts`: tests and examples
-- `NiivueCanvas.tsx`: defines `<NiivueCanvas />`; tight coupling between the functions of `diff.ts` to the React library and Niivue.
-- `playwright/NiivueCanvasForPlaywrightTest.tsx`: a wrapper around `<NiivueCanvas />` to enable Playwright component testing.
-- `tests/playwright/NiivueCanvas.test.tsx`: tests for `<NiivueCanvas />` using Playwright
+- `reexport.ts`: copy-pasted code from [upstream](https://github.com/niivue/niivue) for type definitions which should be public, but aren't.
+- `setters.ts`: generalizes API design inconsistencies of `Niivue` (e.g. how `Niivue.setOpacity` accepts a volume list index number but `Niivue.setColormap` accepts a volume UUID string).
+- `NiivueMutator.ts`: a wrapper for `Niivue` which reconciles the difference in types defined by `model.ts` and accepted parameter types of `Niivue`.
+- `NiivueCanvas.tsx`: defines `<NiivueCanvas />` which integrates React.js with `Niivue` by keeping track of its previous state and syncing changes to its props with `Niivue`'s internal state.
+- `examples/NiivueCanvasForPlaywrightTest.tsx`: a wrapper around `<NiivueCanvas />` for Playwright testing.
 
 ## TODO
 
 - [ ] publish package to NPM
 - [ ] generate and publish documentation
-- [ ] test coverage
+- [x] test coverage

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+# type definition files can be ignored
+ignore:
+  - src/index.ts
+  - src/model.ts
+  - src/reexport.ts

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@vitest/coverage-v8": "^1.2.1",
     "c8": "^9.1.0",
     "happy-dom": "^13.3.1",
-    "playwright-test-coverage-native": "^0.1.2",
+    "playwright-test-coverage-native": "^0.1.3",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.3",
     "use-immer": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -11,22 +11,24 @@
     "fmt": "biome format --write ."
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.5.1",
+    "@biomejs/biome": "^1.5.3",
+    "@niivue/niivue": "^0.39.0",
     "@playwright/test": "^1.41.1",
-    "@types/node": "^20.10.8",
-    "@types/react": "^18.2.47",
+    "@types/node": "^20.11.6",
+    "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
     "@vitest/coverage-v8": "^1.2.1",
     "c8": "^9.1.0",
-    "playwright-test-coverage-native": "^0.1.0",
+    "happy-dom": "^13.3.1",
+    "playwright-test-coverage-native": "^0.1.2",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.3",
     "use-immer": "^0.9.0",
     "vite": "^5.0.12",
-    "vitest": "^1.1.3"
+    "vitest": "^1.2.1"
   },
   "peerDependencies": {
-    "@niivue/niivue": "^0.38.8",
+    "@niivue/niivue": "^0.39.0",
     "react": "^17 || ^18",
     "typescript": "^5.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,8 +41,8 @@ devDependencies:
     specifier: ^13.3.1
     version: 13.3.1
   playwright-test-coverage-native:
-    specifier: ^0.1.2
-    version: 0.1.2(@playwright/test@1.41.1)
+    specifier: ^0.1.3
+    version: 0.1.3(@playwright/test@1.41.1)
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
@@ -1274,8 +1274,8 @@ packages:
     hasBin: true
     dev: true
 
-  /playwright-test-coverage-native@0.1.2(@playwright/test@1.41.1):
-    resolution: {integrity: sha512-li4SzbpabfHzdcEY2NrdnVyiuLMNDzd4RZkP0D4kMraHaxhsrNim3qWeX83+yMStqkWrRKOv6lgDnCfHrBS65A==}
+  /playwright-test-coverage-native@0.1.3(@playwright/test@1.41.1):
+    resolution: {integrity: sha512-EkRswhYJ76olmBS17cOxZgfKZspbvJAsmM623qf8ms3g9AI5UsqqZLPJXQZGM3nGxt7tcZ+BU053jx/wUB0WSA==}
     peerDependencies:
       '@playwright/test': ^1.41.1
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  '@niivue/niivue':
-    specifier: ^0.38.8
-    version: 0.38.8
   react:
     specifier: ^17 || ^18
     version: 18.2.0
@@ -17,29 +14,35 @@ dependencies:
 
 devDependencies:
   '@biomejs/biome':
-    specifier: ^1.5.1
-    version: 1.5.1
+    specifier: ^1.5.3
+    version: 1.5.3
+  '@niivue/niivue':
+    specifier: ^0.39.0
+    version: 0.39.0
   '@playwright/test':
     specifier: ^1.41.1
     version: 1.41.1
   '@types/node':
-    specifier: ^20.10.8
-    version: 20.10.8
+    specifier: ^20.11.6
+    version: 20.11.6
   '@types/react':
-    specifier: ^18.2.47
-    version: 18.2.47
+    specifier: ^18.2.48
+    version: 18.2.48
   '@types/react-dom':
     specifier: ^18.2.18
     version: 18.2.18
   '@vitest/coverage-v8':
     specifier: ^1.2.1
-    version: 1.2.1(vitest@1.1.3)
+    version: 1.2.1(vitest@1.2.1)
   c8:
     specifier: ^9.1.0
     version: 9.1.0
+  happy-dom:
+    specifier: ^13.3.1
+    version: 13.3.1
   playwright-test-coverage-native:
-    specifier: ^0.1.0
-    version: 0.1.0(@playwright/test@1.41.1)
+    specifier: ^0.1.2
+    version: 0.1.2(@playwright/test@1.41.1)
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
@@ -51,10 +54,10 @@ devDependencies:
     version: 0.9.0(immer@10.0.3)(react@18.2.0)
   vite:
     specifier: ^5.0.12
-    version: 5.0.12(@types/node@20.10.8)
+    version: 5.0.12(@types/node@20.11.6)
   vitest:
-    specifier: ^1.1.3
-    version: 1.1.3(@types/node@20.10.8)
+    specifier: ^1.2.1
+    version: 1.2.1(@types/node@20.11.6)(happy-dom@13.3.1)
 
 packages:
 
@@ -97,24 +100,24 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@biomejs/biome@1.5.1:
-    resolution: {integrity: sha512-rdMA/N1Zc1nxUtbXMVr+50Sg/Pezz+9qGQa2uyRWFtrCoyr3dv0pVz+0ifGGue18ip50ZH8x2r5CV7zo8Q/0mA==}
+  /@biomejs/biome@1.5.3:
+    resolution: {integrity: sha512-yvZCa/g3akwTaAQ7PCwPWDCkZs3Qa5ONg/fgOUT9e6wAWsPftCjLQFPXBeGxPK30yZSSpgEmRCfpGTmVbUjGgg==}
     engines: {node: '>=14.*'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 1.5.1
-      '@biomejs/cli-darwin-x64': 1.5.1
-      '@biomejs/cli-linux-arm64': 1.5.1
-      '@biomejs/cli-linux-arm64-musl': 1.5.1
-      '@biomejs/cli-linux-x64': 1.5.1
-      '@biomejs/cli-linux-x64-musl': 1.5.1
-      '@biomejs/cli-win32-arm64': 1.5.1
-      '@biomejs/cli-win32-x64': 1.5.1
+      '@biomejs/cli-darwin-arm64': 1.5.3
+      '@biomejs/cli-darwin-x64': 1.5.3
+      '@biomejs/cli-linux-arm64': 1.5.3
+      '@biomejs/cli-linux-arm64-musl': 1.5.3
+      '@biomejs/cli-linux-x64': 1.5.3
+      '@biomejs/cli-linux-x64-musl': 1.5.3
+      '@biomejs/cli-win32-arm64': 1.5.3
+      '@biomejs/cli-win32-x64': 1.5.3
     dev: true
 
-  /@biomejs/cli-darwin-arm64@1.5.1:
-    resolution: {integrity: sha512-E9pLakmSVHP6UH2uqAghqEkr/IHAIDfDyCedqJVnyFc+uufNTHwB8id4XTiWy/eKIdgxHZsTSE+R+W0IqrTNVQ==}
+  /@biomejs/cli-darwin-arm64@1.5.3:
+    resolution: {integrity: sha512-ImU7mh1HghEDyqNmxEZBoMPr8SxekkZuYcs+gynKlNW+TALQs7swkERiBLkG9NR0K1B3/2uVzlvYowXrmlW8hw==}
     engines: {node: '>=14.*'}
     cpu: [arm64]
     os: [darwin]
@@ -122,8 +125,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-darwin-x64@1.5.1:
-    resolution: {integrity: sha512-8O1F+FcoCi02JlocyilB6R3y3kT9sRkBCRwYddaBIScQe2hCme/mA2rVzrhCCHhskrclJ51GEKjkEORj4/8c2A==}
+  /@biomejs/cli-darwin-x64@1.5.3:
+    resolution: {integrity: sha512-vCdASqYnlpq/swErH7FD6nrFz0czFtK4k/iLgj0/+VmZVjineFPgevOb+Sr9vz0tk0GfdQO60bSpI74zU8M9Dw==}
     engines: {node: '>=14.*'}
     cpu: [x64]
     os: [darwin]
@@ -131,8 +134,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-linux-arm64-musl@1.5.1:
-    resolution: {integrity: sha512-Lw9G3LUdhRMp8L8RMeVevnfQCa7luT6ubQ8GRjLju32glxWKefpDrzgfHixGyvTQPlhnYjQ+V8/QQ/I7WPzOoA==}
+  /@biomejs/cli-linux-arm64-musl@1.5.3:
+    resolution: {integrity: sha512-DYuMizUYUBYfS0IHGjDrOP1RGipqWfMGEvNEJ398zdtmCKLXaUvTimiox5dvx4X15mBK5M2m8wgWUgOP1giUpQ==}
     engines: {node: '>=14.*'}
     cpu: [arm64]
     os: [linux]
@@ -140,8 +143,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-linux-arm64@1.5.1:
-    resolution: {integrity: sha512-25gwY4FMzmi1Rl6N835raLq7nzTk+PyEQd88k9Em6dqtI4qpljqmZlMmVjOiwXKe3Ee80J/Vlh7BM36lsHUTEg==}
+  /@biomejs/cli-linux-arm64@1.5.3:
+    resolution: {integrity: sha512-cupBQv0sNF1OKqBfx7EDWMSsKwRrBUZfjXawT4s6hKV6ALq7p0QzWlxr/sDmbKMLOaLQtw2Qgu/77N9rm+f9Rg==}
     engines: {node: '>=14.*'}
     cpu: [arm64]
     os: [linux]
@@ -149,8 +152,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-linux-x64-musl@1.5.1:
-    resolution: {integrity: sha512-5gapxc/VlwTgGRbTc9h8PMTpf8eNahIBauFUGSXncHgayi3VpezKSicgaQ1bb8FahVXf/5eNEVxVARq/or71Ag==}
+  /@biomejs/cli-linux-x64-musl@1.5.3:
+    resolution: {integrity: sha512-UUHiAnlDqr2Y/LpvshBFhUYMWkl2/Jn+bi3U6jKuav0qWbbBKU/ByHgR4+NBxpKBYoCtWxhnmatfH1bpPIuZMw==}
     engines: {node: '>=14.*'}
     cpu: [x64]
     os: [linux]
@@ -158,8 +161,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-linux-x64@1.5.1:
-    resolution: {integrity: sha512-YDM0gZP4UbAuaBI3DVbUuj5X+Omm6uxzD1Qpc6hcduH1kzXzs9L0ee7cn/kJtNndoXR8MlmUS0O0/wWvZf2YaA==}
+  /@biomejs/cli-linux-x64@1.5.3:
+    resolution: {integrity: sha512-YQrSArQvcv4FYsk7Q91Yv4uuu5F8hJyORVcv3zsjCLGkjIjx2RhjYLpTL733SNL7v33GmOlZY0eFR1ko38tuUw==}
     engines: {node: '>=14.*'}
     cpu: [x64]
     os: [linux]
@@ -167,8 +170,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-win32-arm64@1.5.1:
-    resolution: {integrity: sha512-TVpLBOLUMLQmH2VRFBKFr3rgEkr7XvG4QZxHOxWB9Ivc/sQPvg4aHMd8qpgPKXABGUnultyc9t0+WvfIDxuALg==}
+  /@biomejs/cli-win32-arm64@1.5.3:
+    resolution: {integrity: sha512-HxatYH7vf/kX9nrD+pDYuV2GI9GV8EFo6cfKkahAecTuZLPxryHx1WEfJthp5eNsE0+09STGkKIKjirP0ufaZA==}
     engines: {node: '>=14.*'}
     cpu: [arm64]
     os: [win32]
@@ -176,8 +179,8 @@ packages:
     dev: true
     optional: true
 
-  /@biomejs/cli-win32-x64@1.5.1:
-    resolution: {integrity: sha512-qx8EKwScZmVYZjMPZ6GF3ZUmgg/N6zqh+d8vHA2E43opNCyqIPTl89sOqkc7zd1CyyABDWxsbqI9Ih6xTT6hnQ==}
+  /@biomejs/cli-win32-x64@1.5.3:
+    resolution: {integrity: sha512-fMvbSouZEASU7mZH8SIJSANDm5OqsjgtVXlbUqxwed6BP7uuHRSs396Aqwh2+VoW8fwTpp6ybIUoC9FrzB0kyA==}
     engines: {node: '>=14.*'}
     cpu: [x64]
     os: [win32]
@@ -185,8 +188,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/aix-ppc64@0.19.11:
-    resolution: {integrity: sha512-FnzU0LyE3ySQk7UntJO4+qIiQgI7KoODnZg5xzXIrFJlKd2P2gwHsHY4927xj9y5PJmJSzULiUCWmv7iWnNa7g==}
+  /@esbuild/aix-ppc64@0.19.12:
+    resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [aix]
@@ -194,8 +197,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm64@0.19.11:
-    resolution: {integrity: sha512-aiu7K/5JnLj//KOnOfEZ0D90obUkRzDMyqd/wNAUQ34m4YUPVhRZpnqKV9uqDGxT7cToSDnIHsGooyIczu9T+Q==}
+  /@esbuild/android-arm64@0.19.12:
+    resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -203,8 +206,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm@0.19.11:
-    resolution: {integrity: sha512-5OVapq0ClabvKvQ58Bws8+wkLCV+Rxg7tUVbo9xu034Nm536QTII4YzhaFriQ7rMrorfnFKUsArD2lqKbFY4vw==}
+  /@esbuild/android-arm@0.19.12:
+    resolution: {integrity: sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -212,8 +215,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-x64@0.19.11:
-    resolution: {integrity: sha512-eccxjlfGw43WYoY9QgB82SgGgDbibcqyDTlk3l3C0jOVHKxrjdc9CTwDUQd0vkvYg5um0OH+GpxYvp39r+IPOg==}
+  /@esbuild/android-x64@0.19.12:
+    resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -221,8 +224,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.19.11:
-    resolution: {integrity: sha512-ETp87DRWuSt9KdDVkqSoKoLFHYTrkyz2+65fj9nfXsaV3bMhTCjtQfw3y+um88vGRKRiF7erPrh/ZuIdLUIVxQ==}
+  /@esbuild/darwin-arm64@0.19.12:
+    resolution: {integrity: sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -230,8 +233,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-x64@0.19.11:
-    resolution: {integrity: sha512-fkFUiS6IUK9WYUO/+22omwetaSNl5/A8giXvQlcinLIjVkxwTLSktbF5f/kJMftM2MJp9+fXqZ5ezS7+SALp4g==}
+  /@esbuild/darwin-x64@0.19.12:
+    resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -239,8 +242,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.19.11:
-    resolution: {integrity: sha512-lhoSp5K6bxKRNdXUtHoNc5HhbXVCS8V0iZmDvyWvYq9S5WSfTIHU2UGjcGt7UeS6iEYp9eeymIl5mJBn0yiuxA==}
+  /@esbuild/freebsd-arm64@0.19.12:
+    resolution: {integrity: sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -248,8 +251,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-x64@0.19.11:
-    resolution: {integrity: sha512-JkUqn44AffGXitVI6/AbQdoYAq0TEullFdqcMY/PCUZ36xJ9ZJRtQabzMA+Vi7r78+25ZIBosLTOKnUXBSi1Kw==}
+  /@esbuild/freebsd-x64@0.19.12:
+    resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -257,8 +260,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm64@0.19.11:
-    resolution: {integrity: sha512-LneLg3ypEeveBSMuoa0kwMpCGmpu8XQUh+mL8XXwoYZ6Be2qBnVtcDI5azSvh7vioMDhoJFZzp9GWp9IWpYoUg==}
+  /@esbuild/linux-arm64@0.19.12:
+    resolution: {integrity: sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -266,8 +269,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm@0.19.11:
-    resolution: {integrity: sha512-3CRkr9+vCV2XJbjwgzjPtO8T0SZUmRZla+UL1jw+XqHZPkPgZiyWvbDvl9rqAN8Zl7qJF0O/9ycMtjU67HN9/Q==}
+  /@esbuild/linux-arm@0.19.12:
+    resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -275,8 +278,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ia32@0.19.11:
-    resolution: {integrity: sha512-caHy++CsD8Bgq2V5CodbJjFPEiDPq8JJmBdeyZ8GWVQMjRD0sU548nNdwPNvKjVpamYYVL40AORekgfIubwHoA==}
+  /@esbuild/linux-ia32@0.19.12:
+    resolution: {integrity: sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -284,8 +287,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-loong64@0.19.11:
-    resolution: {integrity: sha512-ppZSSLVpPrwHccvC6nQVZaSHlFsvCQyjnvirnVjbKSHuE5N24Yl8F3UwYUUR1UEPaFObGD2tSvVKbvR+uT1Nrg==}
+  /@esbuild/linux-loong64@0.19.12:
+    resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -293,8 +296,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.19.11:
-    resolution: {integrity: sha512-B5x9j0OgjG+v1dF2DkH34lr+7Gmv0kzX6/V0afF41FkPMMqaQ77pH7CrhWeR22aEeHKaeZVtZ6yFwlxOKPVFyg==}
+  /@esbuild/linux-mips64el@0.19.12:
+    resolution: {integrity: sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -302,8 +305,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ppc64@0.19.11:
-    resolution: {integrity: sha512-MHrZYLeCG8vXblMetWyttkdVRjQlQUb/oMgBNurVEnhj4YWOr4G5lmBfZjHYQHHN0g6yDmCAQRR8MUHldvvRDA==}
+  /@esbuild/linux-ppc64@0.19.12:
+    resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -311,8 +314,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.19.11:
-    resolution: {integrity: sha512-f3DY++t94uVg141dozDu4CCUkYW+09rWtaWfnb3bqe4w5NqmZd6nPVBm+qbz7WaHZCoqXqHz5p6CM6qv3qnSSQ==}
+  /@esbuild/linux-riscv64@0.19.12:
+    resolution: {integrity: sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -320,8 +323,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-s390x@0.19.11:
-    resolution: {integrity: sha512-A5xdUoyWJHMMlcSMcPGVLzYzpcY8QP1RtYzX5/bS4dvjBGVxdhuiYyFwp7z74ocV7WDc0n1harxmpq2ePOjI0Q==}
+  /@esbuild/linux-s390x@0.19.12:
+    resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -329,8 +332,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-x64@0.19.11:
-    resolution: {integrity: sha512-grbyMlVCvJSfxFQUndw5mCtWs5LO1gUlwP4CDi4iJBbVpZcqLVT29FxgGuBJGSzyOxotFG4LoO5X+M1350zmPA==}
+  /@esbuild/linux-x64@0.19.12:
+    resolution: {integrity: sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -338,8 +341,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/netbsd-x64@0.19.11:
-    resolution: {integrity: sha512-13jvrQZJc3P230OhU8xgwUnDeuC/9egsjTkXN49b3GcS5BKvJqZn86aGM8W9pd14Kd+u7HuFBMVtrNGhh6fHEQ==}
+  /@esbuild/netbsd-x64@0.19.12:
+    resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -347,8 +350,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.19.11:
-    resolution: {integrity: sha512-ysyOGZuTp6SNKPE11INDUeFVVQFrhcNDVUgSQVDzqsqX38DjhPEPATpid04LCoUr2WXhQTEZ8ct/EgJCUDpyNw==}
+  /@esbuild/openbsd-x64@0.19.12:
+    resolution: {integrity: sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -356,8 +359,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/sunos-x64@0.19.11:
-    resolution: {integrity: sha512-Hf+Sad9nVwvtxy4DXCZQqLpgmRTQqyFyhT3bZ4F2XlJCjxGmRFF0Shwn9rzhOYRB61w9VMXUkxlBy56dk9JJiQ==}
+  /@esbuild/sunos-x64@0.19.12:
+    resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -365,8 +368,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-arm64@0.19.11:
-    resolution: {integrity: sha512-0P58Sbi0LctOMOQbpEOvOL44Ne0sqbS0XWHMvvrg6NE5jQ1xguCSSw9jQeUk2lfrXYsKDdOe6K+oZiwKPilYPQ==}
+  /@esbuild/win32-arm64@0.19.12:
+    resolution: {integrity: sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -374,8 +377,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-ia32@0.19.11:
-    resolution: {integrity: sha512-6YOrWS+sDJDmshdBIQU+Uoyh7pQKrdykdefC1avn76ss5c+RN6gut3LZA4E2cH5xUEp5/cA0+YxRaVtRAb0xBg==}
+  /@esbuild/win32-ia32@0.19.12:
+    resolution: {integrity: sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -383,8 +386,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-x64@0.19.11:
-    resolution: {integrity: sha512-vfkhltrjCAb603XaFhqhAF4LGDi2M4OrCRrFusyQ+iTLQ/o60QQXxc9cZC/FFpihBI9N1Grn6SMKVJ4KP7Fuiw==}
+  /@esbuild/win32-x64@0.19.12:
+    resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -437,17 +440,17 @@ packages:
   /@lukeed/csprng@1.1.0:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
-    dev: false
+    dev: true
 
   /@lukeed/uuid@2.0.1:
     resolution: {integrity: sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==}
     engines: {node: '>=8'}
     dependencies:
       '@lukeed/csprng': 1.1.0
-    dev: false
+    dev: true
 
-  /@niivue/niivue@0.38.8:
-    resolution: {integrity: sha512-m2uC4kqKpwdk6y+heJSpVnysYDp7IW06MsYVw9ccdKnNOwI9DWUweBR93IsiPbHrTVohPqpjeAjufnjAbS5PTA==}
+  /@niivue/niivue@0.39.0:
+    resolution: {integrity: sha512-j7vyd5BpkyX+liO6LNa0zGiCp75RoeC3gzijATlVwyeF+0T391doldfUEwIAaolbN8JxfUlgZxMnsBcHKR9gGQ==}
     dependencies:
       '@lukeed/uuid': 2.0.1
       '@ungap/structured-clone': 1.2.0
@@ -458,8 +461,8 @@ packages:
       nifti-reader-js: 0.6.8
       rxjs: 7.8.1
     optionalDependencies:
-      '@rollup/rollup-linux-x64-gnu': 4.9.4
-    dev: false
+      '@rollup/rollup-linux-x64-gnu': 4.9.6
+    dev: true
 
   /@playwright/test@1.41.1:
     resolution: {integrity: sha512-9g8EWTjiQ9yFBXc6HjCWe41msLpxEX0KhmfmPl9RPLJdfzL4F0lg2BdJ91O9azFdl11y1pmpwdjBiSxvqc+btw==}
@@ -474,103 +477,104 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: true
 
-  /@rollup/rollup-android-arm-eabi@4.9.4:
-    resolution: {integrity: sha512-ub/SN3yWqIv5CWiAZPHVS1DloyZsJbtXmX4HxUTIpS0BHm9pW5iYBo2mIZi+hE3AeiTzHz33blwSnhdUo+9NpA==}
+  /@rollup/rollup-android-arm-eabi@4.9.6:
+    resolution: {integrity: sha512-MVNXSSYN6QXOulbHpLMKYi60ppyO13W9my1qogeiAqtjb2yR4LSmfU2+POvDkLzhjYLXz9Rf9+9a3zFHW1Lecg==}
     cpu: [arm]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-android-arm64@4.9.4:
-    resolution: {integrity: sha512-ehcBrOR5XTl0W0t2WxfTyHCR/3Cq2jfb+I4W+Ch8Y9b5G+vbAecVv0Fx/J1QKktOrgUYsIKxWAKgIpvw56IFNA==}
+  /@rollup/rollup-android-arm64@4.9.6:
+    resolution: {integrity: sha512-T14aNLpqJ5wzKNf5jEDpv5zgyIqcpn1MlwCrUXLrwoADr2RkWA0vOWP4XxbO9aiO3dvMCQICZdKeDrFl7UMClw==}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-darwin-arm64@4.9.4:
-    resolution: {integrity: sha512-1fzh1lWExwSTWy8vJPnNbNM02WZDS8AW3McEOb7wW+nPChLKf3WG2aG7fhaUmfX5FKw9zhsF5+MBwArGyNM7NA==}
+  /@rollup/rollup-darwin-arm64@4.9.6:
+    resolution: {integrity: sha512-CqNNAyhRkTbo8VVZ5R85X73H3R5NX9ONnKbXuHisGWC0qRbTTxnF1U4V9NafzJbgGM0sHZpdO83pLPzq8uOZFw==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-darwin-x64@4.9.4:
-    resolution: {integrity: sha512-Gc6cukkF38RcYQ6uPdiXi70JB0f29CwcQ7+r4QpfNpQFVHXRd0DfWFidoGxjSx1DwOETM97JPz1RXL5ISSB0pA==}
+  /@rollup/rollup-darwin-x64@4.9.6:
+    resolution: {integrity: sha512-zRDtdJuRvA1dc9Mp6BWYqAsU5oeLixdfUvkTHuiYOHwqYuQ4YgSmi6+/lPvSsqc/I0Omw3DdICx4Tfacdzmhog==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.9.4:
-    resolution: {integrity: sha512-g21RTeFzoTl8GxosHbnQZ0/JkuFIB13C3T7Y0HtKzOXmoHhewLbVTFBQZu+z5m9STH6FZ7L/oPgU4Nm5ErN2fw==}
+  /@rollup/rollup-linux-arm-gnueabihf@4.9.6:
+    resolution: {integrity: sha512-oNk8YXDDnNyG4qlNb6is1ojTOGL/tRhbbKeE/YuccItzerEZT68Z9gHrY3ROh7axDc974+zYAPxK5SH0j/G+QQ==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-gnu@4.9.4:
-    resolution: {integrity: sha512-TVYVWD/SYwWzGGnbfTkrNpdE4HON46orgMNHCivlXmlsSGQOx/OHHYiQcMIOx38/GWgwr/po2LBn7wypkWw/Mg==}
+  /@rollup/rollup-linux-arm64-gnu@4.9.6:
+    resolution: {integrity: sha512-Z3O60yxPtuCYobrtzjo0wlmvDdx2qZfeAWTyfOjEDqd08kthDKexLpV97KfAeUXPosENKd8uyJMRDfFMxcYkDQ==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-musl@4.9.4:
-    resolution: {integrity: sha512-XcKvuendwizYYhFxpvQ3xVpzje2HHImzg33wL9zvxtj77HvPStbSGI9czrdbfrf8DGMcNNReH9pVZv8qejAQ5A==}
+  /@rollup/rollup-linux-arm64-musl@4.9.6:
+    resolution: {integrity: sha512-gpiG0qQJNdYEVad+1iAsGAbgAnZ8j07FapmnIAQgODKcOTjLEWM9sRb+MbQyVsYCnA0Im6M6QIq6ax7liws6eQ==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-riscv64-gnu@4.9.4:
-    resolution: {integrity: sha512-LFHS/8Q+I9YA0yVETyjonMJ3UA+DczeBd/MqNEzsGSTdNvSJa1OJZcSH8GiXLvcizgp9AlHs2walqRcqzjOi3A==}
+  /@rollup/rollup-linux-riscv64-gnu@4.9.6:
+    resolution: {integrity: sha512-+uCOcvVmFUYvVDr27aiyun9WgZk0tXe7ThuzoUTAukZJOwS5MrGbmSlNOhx1j80GdpqbOty05XqSl5w4dQvcOA==}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-x64-gnu@4.9.4:
-    resolution: {integrity: sha512-dIYgo+j1+yfy81i0YVU5KnQrIJZE8ERomx17ReU4GREjGtDW4X+nvkBak2xAUpyqLs4eleDSj3RrV72fQos7zw==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@rollup/rollup-linux-x64-musl@4.9.4:
-    resolution: {integrity: sha512-RoaYxjdHQ5TPjaPrLsfKqR3pakMr3JGqZ+jZM0zP2IkDtsGa4CqYaWSfQmZVgFUCgLrTnzX+cnHS3nfl+kB6ZQ==}
+  /@rollup/rollup-linux-x64-gnu@4.9.6:
+    resolution: {integrity: sha512-HUNqM32dGzfBKuaDUBqFB7tP6VMN74eLZ33Q9Y1TBqRDn+qDonkAUyKWwF9BR9unV7QUzffLnz9GrnKvMqC/fw==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-arm64-msvc@4.9.4:
-    resolution: {integrity: sha512-T8Q3XHV+Jjf5e49B4EAaLKV74BbX7/qYBRQ8Wop/+TyyU0k+vSjiLVSHNWdVd1goMjZcbhDmYZUYW5RFqkBNHQ==}
+  /@rollup/rollup-linux-x64-musl@4.9.6:
+    resolution: {integrity: sha512-ch7M+9Tr5R4FK40FHQk8VnML0Szi2KRujUgHXd/HjuH9ifH72GUmw6lStZBo3c3GB82vHa0ZoUfjfcM7JiiMrQ==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-arm64-msvc@4.9.6:
+    resolution: {integrity: sha512-VD6qnR99dhmTQ1mJhIzXsRcTBvTjbfbGGwKAHcu+52cVl15AC/kplkhxzW/uT0Xl62Y/meBKDZvoJSJN+vTeGA==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-ia32-msvc@4.9.4:
-    resolution: {integrity: sha512-z+JQ7JirDUHAsMecVydnBPWLwJjbppU+7LZjffGf+Jvrxq+dVjIE7By163Sc9DKc3ADSU50qPVw0KonBS+a+HQ==}
+  /@rollup/rollup-win32-ia32-msvc@4.9.6:
+    resolution: {integrity: sha512-J9AFDq/xiRI58eR2NIDfyVmTYGyIZmRcvcAoJ48oDld/NTR8wyiPUu2X/v1navJ+N/FGg68LEbX3Ejd6l8B7MQ==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-x64-msvc@4.9.4:
-    resolution: {integrity: sha512-LfdGXCV9rdEify1oxlN9eamvDSjv9md9ZVMAbNHA87xqIfFCxImxan9qZ8+Un54iK2nnqPlbnSi4R54ONtbWBw==}
+  /@rollup/rollup-win32-x64-msvc@4.9.6:
+    resolution: {integrity: sha512-jqzNLhNDvIZOrt69Ce4UjGRpXJBzhUBzawMwnaDAwyHriki3XollsewxWzOzz+4yOFDkuJHtTsZFwMxhYJWmLQ==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -589,8 +593,8 @@ packages:
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
     dev: true
 
-  /@types/node@20.10.8:
-    resolution: {integrity: sha512-f8nQs3cLxbAFc00vEU59yf9UyGUftkPaLGfvbVOIDdx2i1b8epBqj2aNGyP19fiyXWvlmZ7qC1XLjAzw/OKIeA==}
+  /@types/node@20.11.6:
+    resolution: {integrity: sha512-+EOokTnksGVgip2PbYbr3xnR7kZigh4LbybAfBAw5BpnQ+FqBYUsvCEjYd70IXKlbohQ64mzEYmMtlWUY8q//Q==}
     dependencies:
       undici-types: 5.26.5
     dev: true
@@ -602,11 +606,11 @@ packages:
   /@types/react-dom@18.2.18:
     resolution: {integrity: sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==}
     dependencies:
-      '@types/react': 18.2.47
+      '@types/react': 18.2.48
     dev: true
 
-  /@types/react@18.2.47:
-    resolution: {integrity: sha512-xquNkkOirwyCgoClNk85BjP+aqnIS+ckAJ8i37gAbDs14jfW/J23f2GItAf33oiUPQnqNMALiFeoM9Y5mbjpVQ==}
+  /@types/react@18.2.48:
+    resolution: {integrity: sha512-qboRCl6Ie70DQQG9hhNREz81jqC1cs9EVNcjQ1AU+jH6NFfSAhVVbrrY/+nSF+Bsk4AOwm9Qa61InvMCyV+H3w==}
     dependencies:
       '@types/prop-types': 15.7.11
       '@types/scheduler': 0.16.8
@@ -619,9 +623,9 @@ packages:
 
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
-    dev: false
+    dev: true
 
-  /@vitest/coverage-v8@1.2.1(vitest@1.1.3):
+  /@vitest/coverage-v8@1.2.1(vitest@1.2.1):
     resolution: {integrity: sha512-fJEhKaDwGMZtJUX7BRcGxooGwg1Hl0qt53mVup/ZJeznhvL5EodteVnb/mcByhEcvVWbK83ZF31c7nPEDi4LOQ==}
     peerDependencies:
       vitest: ^1.0.0
@@ -639,43 +643,43 @@ packages:
       std-env: 3.7.0
       test-exclude: 6.0.0
       v8-to-istanbul: 9.2.0
-      vitest: 1.1.3(@types/node@20.10.8)
+      vitest: 1.2.1(@types/node@20.11.6)(happy-dom@13.3.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@vitest/expect@1.1.3:
-    resolution: {integrity: sha512-MnJqsKc1Ko04lksF9XoRJza0bGGwTtqfbyrsYv5on4rcEkdo+QgUdITenBQBUltKzdxW7K3rWh+nXRULwsdaVg==}
+  /@vitest/expect@1.2.1:
+    resolution: {integrity: sha512-/bqGXcHfyKgFWYwIgFr1QYDaR9e64pRKxgBNWNXPefPFRhgm+K3+a/dS0cUGEreWngets3dlr8w8SBRw2fCfFQ==}
     dependencies:
-      '@vitest/spy': 1.1.3
-      '@vitest/utils': 1.1.3
-      chai: 4.4.0
+      '@vitest/spy': 1.2.1
+      '@vitest/utils': 1.2.1
+      chai: 4.4.1
     dev: true
 
-  /@vitest/runner@1.1.3:
-    resolution: {integrity: sha512-Va2XbWMnhSdDEh/OFxyUltgQuuDRxnarK1hW5QNN4URpQrqq6jtt8cfww/pQQ4i0LjoYxh/3bYWvDFlR9tU73g==}
+  /@vitest/runner@1.2.1:
+    resolution: {integrity: sha512-zc2dP5LQpzNzbpaBt7OeYAvmIsRS1KpZQw4G3WM/yqSV1cQKNKwLGmnm79GyZZjMhQGlRcSFMImLjZaUQvNVZQ==}
     dependencies:
-      '@vitest/utils': 1.1.3
+      '@vitest/utils': 1.2.1
       p-limit: 5.0.0
       pathe: 1.1.2
     dev: true
 
-  /@vitest/snapshot@1.1.3:
-    resolution: {integrity: sha512-U0r8pRXsLAdxSVAyGNcqOU2H3Z4Y2dAAGGelL50O0QRMdi1WWeYHdrH/QWpN1e8juWfVKsb8B+pyJwTC+4Gy9w==}
+  /@vitest/snapshot@1.2.1:
+    resolution: {integrity: sha512-Tmp/IcYEemKaqAYCS08sh0vORLJkMr0NRV76Gl8sHGxXT5151cITJCET20063wk0Yr/1koQ6dnmP6eEqezmd/Q==}
     dependencies:
       magic-string: 0.30.5
       pathe: 1.1.2
       pretty-format: 29.7.0
     dev: true
 
-  /@vitest/spy@1.1.3:
-    resolution: {integrity: sha512-Ec0qWyGS5LhATFQtldvChPTAHv08yHIOZfiNcjwRQbFPHpkih0md9KAbs7TfeIfL7OFKoe7B/6ukBTqByubXkQ==}
+  /@vitest/spy@1.2.1:
+    resolution: {integrity: sha512-vG3a/b7INKH7L49Lbp0IWrG6sw9j4waWAucwnksPB1r1FTJgV7nkBByd9ufzu6VWya/QTvQW4V9FShZbZIB2UQ==}
     dependencies:
       tinyspy: 2.2.0
     dev: true
 
-  /@vitest/utils@1.1.3:
-    resolution: {integrity: sha512-Dyt3UMcdElTll2H75vhxfpZu03uFpXRCHxWnzcrFjZxT1kTbq8ALUYIeBgGolo1gldVdI0YSlQRacsqxTwNqwg==}
+  /@vitest/utils@1.2.1:
+    resolution: {integrity: sha512-bsH6WVZYe/J2v3+81M5LDU8kW76xWObKIURpPrOXm2pjBniBu2MERI/XP60GpS4PHU3jyK50LUutOwrx4CyHUg==}
     dependencies:
       diff-sequences: 29.6.3
       estree-walker: 3.0.3
@@ -686,10 +690,10 @@ packages:
   /@wearemothership/dicom-character-set@1.0.4-opt.1:
     resolution: {integrity: sha512-stqhnpawYHY2UZKj4RHTF71ab3q3z8S1SO9ToQKjsHQwowUdFVo6YFea93psFux3yqNbRlQjwoCdPjHcD0YQzw==}
     engines: {node: '>=10'}
-    dev: false
+    dev: true
 
-  /acorn-walk@8.3.1:
-    resolution: {integrity: sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==}
+  /acorn-walk@8.3.2:
+    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
     engines: {node: '>=0.4.0'}
     dev: true
 
@@ -718,7 +722,7 @@ packages:
 
   /array-equal@1.0.2:
     resolution: {integrity: sha512-gUHx76KtnhEgB3HOuFYiCm3FIdEs6ocM2asHvNTkfu/Y09qQVrrVVaOKENmS2KkSaGoxgXNqC+ZVtR/n0MOkSA==}
-    dev: false
+    dev: true
 
   /assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
@@ -758,8 +762,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /chai@4.4.0:
-    resolution: {integrity: sha512-x9cHNq1uvkCdU+5xTkNh5WtgD4e4yDFCsp9jVc7N7qVeKeftv3gO/ZrviX5d+3ZfxdYnZXZYujjRInu1RogU6A==}
+  /chai@4.4.1:
+    resolution: {integrity: sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==}
     engines: {node: '>=4'}
     dependencies:
       assertion-error: 1.1.0
@@ -826,7 +830,7 @@ packages:
       jpeg-lossless-decoder-js: 2.0.7
       pako: 1.0.11
       xss: 0.0.9
-    dev: false
+    dev: true
 
   /debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -856,35 +860,40 @@ packages:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
     dev: true
 
-  /esbuild@0.19.11:
-    resolution: {integrity: sha512-HJ96Hev2hX/6i5cDVwcqiJBBtuo9+FeIJOtZ9W1kA5M6AMJRHUZlpYZ1/SbEwtO0ioNAW8rUooVpC/WehY2SfA==}
+  /entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+    dev: true
+
+  /esbuild@0.19.12:
+    resolution: {integrity: sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==}
     engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.19.11
-      '@esbuild/android-arm': 0.19.11
-      '@esbuild/android-arm64': 0.19.11
-      '@esbuild/android-x64': 0.19.11
-      '@esbuild/darwin-arm64': 0.19.11
-      '@esbuild/darwin-x64': 0.19.11
-      '@esbuild/freebsd-arm64': 0.19.11
-      '@esbuild/freebsd-x64': 0.19.11
-      '@esbuild/linux-arm': 0.19.11
-      '@esbuild/linux-arm64': 0.19.11
-      '@esbuild/linux-ia32': 0.19.11
-      '@esbuild/linux-loong64': 0.19.11
-      '@esbuild/linux-mips64el': 0.19.11
-      '@esbuild/linux-ppc64': 0.19.11
-      '@esbuild/linux-riscv64': 0.19.11
-      '@esbuild/linux-s390x': 0.19.11
-      '@esbuild/linux-x64': 0.19.11
-      '@esbuild/netbsd-x64': 0.19.11
-      '@esbuild/openbsd-x64': 0.19.11
-      '@esbuild/sunos-x64': 0.19.11
-      '@esbuild/win32-arm64': 0.19.11
-      '@esbuild/win32-ia32': 0.19.11
-      '@esbuild/win32-x64': 0.19.11
+      '@esbuild/aix-ppc64': 0.19.12
+      '@esbuild/android-arm': 0.19.12
+      '@esbuild/android-arm64': 0.19.12
+      '@esbuild/android-x64': 0.19.12
+      '@esbuild/darwin-arm64': 0.19.12
+      '@esbuild/darwin-x64': 0.19.12
+      '@esbuild/freebsd-arm64': 0.19.12
+      '@esbuild/freebsd-x64': 0.19.12
+      '@esbuild/linux-arm': 0.19.12
+      '@esbuild/linux-arm64': 0.19.12
+      '@esbuild/linux-ia32': 0.19.12
+      '@esbuild/linux-loong64': 0.19.12
+      '@esbuild/linux-mips64el': 0.19.12
+      '@esbuild/linux-ppc64': 0.19.12
+      '@esbuild/linux-riscv64': 0.19.12
+      '@esbuild/linux-s390x': 0.19.12
+      '@esbuild/linux-x64': 0.19.12
+      '@esbuild/netbsd-x64': 0.19.12
+      '@esbuild/openbsd-x64': 0.19.12
+      '@esbuild/sunos-x64': 0.19.12
+      '@esbuild/win32-arm64': 0.19.12
+      '@esbuild/win32-ia32': 0.19.12
+      '@esbuild/win32-x64': 0.19.12
     dev: true
 
   /escalade@3.1.1:
@@ -915,7 +924,7 @@ packages:
 
   /fflate@0.7.4:
     resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
-    dev: false
+    dev: true
 
   /find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -969,7 +978,7 @@ packages:
 
   /gl-matrix@3.4.3:
     resolution: {integrity: sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==}
-    dev: false
+    dev: true
 
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -980,6 +989,15 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
+    dev: true
+
+  /happy-dom@13.3.1:
+    resolution: {integrity: sha512-KIlztn+nRWstprUyI3Wzy1UJrg72uOaoo4SaBLNrV6xrn2Rq86eQruKOL7ZyDhkfou3nEZX6rgRYtvsqwMInvQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      entities: 4.5.0
+      webidl-conversions: 7.0.0
+      whatwg-mimetype: 3.0.0
     dev: true
 
   /has-flag@4.0.0:
@@ -1060,20 +1078,20 @@ packages:
 
   /jpeg-lossless-decoder-js@2.0.7:
     resolution: {integrity: sha512-tbZlhFkKmx+JaqVMkq47SKWGuXLkIaV8fTbnhO39dYEnQrSShLGuLCGb0n6ntXjtmk6oAWGiIriWOLwj9od0yQ==}
-    dev: false
+    dev: true
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  /jsonc-parser@3.2.0:
-    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
+  /jsonc-parser@3.2.1:
+    resolution: {integrity: sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==}
     dev: true
 
   /local-pkg@0.5.0:
     resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
     engines: {node: '>=14'}
     dependencies:
-      mlly: 1.4.2
+      mlly: 1.5.0
       pkg-types: 1.0.3
     dev: true
 
@@ -1140,8 +1158,8 @@ packages:
       brace-expansion: 1.1.11
     dev: true
 
-  /mlly@1.4.2:
-    resolution: {integrity: sha512-i/Ykufi2t1EZ6NaPLdfnZk2AX8cs0d+mTzVKuPfqPKPatxLApaBoxJQ9x1/uckXtrS/U5oisPMDkNs0yQTaBRg==}
+  /mlly@1.5.0:
+    resolution: {integrity: sha512-NPVQvAY1xr1QoVeG0cy8yUYC7FQcOx6evl/RjT1wL5FvzPnzOysoqB/jmx/DhssT2dYa8nxECLAaFI/+gVLhDQ==}
     dependencies:
       acorn: 8.11.3
       pathe: 1.1.2
@@ -1163,7 +1181,7 @@ packages:
     resolution: {integrity: sha512-yIKNVzYFiUcSHazoR+sd6Ka7sUmZTabaVqJRFxbdlAKR1hnPBuNP71g3AyApo37nJ3k41c632QPij5q7gF1YPQ==}
     dependencies:
       fflate: 0.7.4
-    dev: false
+    dev: true
 
   /npm-run-path@5.2.0:
     resolution: {integrity: sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==}
@@ -1208,7 +1226,7 @@ packages:
 
   /pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
-    dev: false
+    dev: true
 
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -1245,8 +1263,8 @@ packages:
   /pkg-types@1.0.3:
     resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
     dependencies:
-      jsonc-parser: 3.2.0
-      mlly: 1.4.2
+      jsonc-parser: 3.2.1
+      mlly: 1.5.0
       pathe: 1.1.2
     dev: true
 
@@ -1256,8 +1274,8 @@ packages:
     hasBin: true
     dev: true
 
-  /playwright-test-coverage-native@0.1.0(@playwright/test@1.41.1):
-    resolution: {integrity: sha512-k49pGGChaWkmdWBZ+RwcAqv/75IegpFsKozklLb8qug9K6CJYc/s3ITSw6NNdiDhGHdcw0M0LpcocErlOuCNOw==}
+  /playwright-test-coverage-native@0.1.2(@playwright/test@1.41.1):
+    resolution: {integrity: sha512-li4SzbpabfHzdcEY2NrdnVyiuLMNDzd4RZkP0D4kMraHaxhsrNim3qWeX83+yMStqkWrRKOv6lgDnCfHrBS65A==}
     peerDependencies:
       '@playwright/test': ^1.41.1
     dependencies:
@@ -1340,26 +1358,26 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /rollup@4.9.4:
-    resolution: {integrity: sha512-2ztU7pY/lrQyXSCnnoU4ICjT/tCG9cdH3/G25ERqE3Lst6vl2BCM5hL2Nw+sslAvAf+ccKsAq1SkKQALyqhR7g==}
+  /rollup@4.9.6:
+    resolution: {integrity: sha512-05lzkCS2uASX0CiLFybYfVkwNbKZG5NFQ6Go0VWyogFTXXbR039UVsegViTntkk4OglHBdF54ccApXRRuXRbsg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
     dependencies:
       '@types/estree': 1.0.5
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.9.4
-      '@rollup/rollup-android-arm64': 4.9.4
-      '@rollup/rollup-darwin-arm64': 4.9.4
-      '@rollup/rollup-darwin-x64': 4.9.4
-      '@rollup/rollup-linux-arm-gnueabihf': 4.9.4
-      '@rollup/rollup-linux-arm64-gnu': 4.9.4
-      '@rollup/rollup-linux-arm64-musl': 4.9.4
-      '@rollup/rollup-linux-riscv64-gnu': 4.9.4
-      '@rollup/rollup-linux-x64-gnu': 4.9.4
-      '@rollup/rollup-linux-x64-musl': 4.9.4
-      '@rollup/rollup-win32-arm64-msvc': 4.9.4
-      '@rollup/rollup-win32-ia32-msvc': 4.9.4
-      '@rollup/rollup-win32-x64-msvc': 4.9.4
+      '@rollup/rollup-android-arm-eabi': 4.9.6
+      '@rollup/rollup-android-arm64': 4.9.6
+      '@rollup/rollup-darwin-arm64': 4.9.6
+      '@rollup/rollup-darwin-x64': 4.9.6
+      '@rollup/rollup-linux-arm-gnueabihf': 4.9.6
+      '@rollup/rollup-linux-arm64-gnu': 4.9.6
+      '@rollup/rollup-linux-arm64-musl': 4.9.6
+      '@rollup/rollup-linux-riscv64-gnu': 4.9.6
+      '@rollup/rollup-linux-x64-gnu': 4.9.6
+      '@rollup/rollup-linux-x64-musl': 4.9.6
+      '@rollup/rollup-win32-arm64-msvc': 4.9.6
+      '@rollup/rollup-win32-ia32-msvc': 4.9.6
+      '@rollup/rollup-win32-x64-msvc': 4.9.6
       fsevents: 2.3.3
     dev: true
 
@@ -1367,7 +1385,7 @@ packages:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
     dependencies:
       tslib: 2.6.2
-    dev: false
+    dev: true
 
   /scheduler@0.23.0:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
@@ -1465,12 +1483,12 @@ packages:
       minimatch: 3.1.2
     dev: true
 
-  /tinybench@2.5.1:
-    resolution: {integrity: sha512-65NKvSuAVDP/n4CqH+a9w2kTlLReS9vhsAP06MWx+/89nMinJyB2icyl58RIcqCmIggpojIGeuJGhjU1aGMBSg==}
+  /tinybench@2.6.0:
+    resolution: {integrity: sha512-N8hW3PG/3aOoZAN5V/NSAEDz0ZixDSSt5b/a05iqtpgfLWMSVuCo7w0k2vVvEjdrIoeGqZzweX2WlyioNIHchA==}
     dev: true
 
-  /tinypool@0.8.1:
-    resolution: {integrity: sha512-zBTCK0cCgRROxvs9c0CGK838sPkeokNGdQVUUwHAbynHFlmyJYj825f/oRs528HaIJ97lo0pLIlDUzwN+IorWg==}
+  /tinypool@0.8.2:
+    resolution: {integrity: sha512-SUszKYe5wgsxnNOVlBYO6IC+8VGWdVGZWAqUxp3UErNBtptZvWbwyUOyzNL59zigz2rCA92QiL3wvG+JDSdJdQ==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -1486,7 +1504,7 @@ packages:
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
-    dev: false
+    dev: true
 
   /type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
@@ -1526,8 +1544,8 @@ packages:
       convert-source-map: 2.0.0
     dev: true
 
-  /vite-node@1.1.3(@types/node@20.10.8):
-    resolution: {integrity: sha512-BLSO72YAkIUuNrOx+8uznYICJfTEbvBAmWClY3hpath5+h1mbPS5OMn42lrTxXuyCazVyZoDkSRnju78GiVCqA==}
+  /vite-node@1.2.1(@types/node@20.11.6):
+    resolution: {integrity: sha512-fNzHmQUSOY+y30naohBvSW7pPn/xn3Ib/uqm+5wAJQJiqQsU0NBR78XdRJb04l4bOFKjpTWld0XAfkKlrDbySg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     dependencies:
@@ -1535,7 +1553,7 @@ packages:
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.0.12(@types/node@20.10.8)
+      vite: 5.0.12(@types/node@20.11.6)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -1547,7 +1565,7 @@ packages:
       - terser
     dev: true
 
-  /vite@5.0.12(@types/node@20.10.8):
+  /vite@5.0.12(@types/node@20.11.6):
     resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -1575,16 +1593,16 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.10.8
-      esbuild: 0.19.11
+      '@types/node': 20.11.6
+      esbuild: 0.19.12
       postcss: 8.4.33
-      rollup: 4.9.4
+      rollup: 4.9.6
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.1.3(@types/node@20.10.8):
-    resolution: {integrity: sha512-2l8om1NOkiA90/Y207PsEvJLYygddsOyr81wLQ20Ra8IlLKbyQncWsGZjnbkyG2KwwuTXLQjEPOJuxGMG8qJBQ==}
+  /vitest@1.2.1(@types/node@20.11.6)(happy-dom@13.3.1):
+    resolution: {integrity: sha512-TRph8N8rnSDa5M2wKWJCMnztCZS9cDcgVTQ6tsTFTG/odHJ4l5yNVqvbeDJYJRZ6is3uxaEpFs8LL6QM+YFSdA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -1608,27 +1626,28 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@types/node': 20.10.8
-      '@vitest/expect': 1.1.3
-      '@vitest/runner': 1.1.3
-      '@vitest/snapshot': 1.1.3
-      '@vitest/spy': 1.1.3
-      '@vitest/utils': 1.1.3
-      acorn-walk: 8.3.1
+      '@types/node': 20.11.6
+      '@vitest/expect': 1.2.1
+      '@vitest/runner': 1.2.1
+      '@vitest/snapshot': 1.2.1
+      '@vitest/spy': 1.2.1
+      '@vitest/utils': 1.2.1
+      acorn-walk: 8.3.2
       cac: 6.7.14
-      chai: 4.4.0
+      chai: 4.4.1
       debug: 4.3.4
       execa: 8.0.1
+      happy-dom: 13.3.1
       local-pkg: 0.5.0
       magic-string: 0.30.5
       pathe: 1.1.2
       picocolors: 1.0.0
       std-env: 3.7.0
       strip-literal: 1.3.0
-      tinybench: 2.5.1
-      tinypool: 0.8.1
-      vite: 5.0.12(@types/node@20.10.8)
-      vite-node: 1.1.3(@types/node@20.10.8)
+      tinybench: 2.6.0
+      tinypool: 0.8.2
+      vite: 5.0.12(@types/node@20.11.6)
+      vite-node: 1.2.1(@types/node@20.11.6)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -1638,6 +1657,16 @@ packages:
       - sugarss
       - supports-color
       - terser
+    dev: true
+
+  /webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
     dev: true
 
   /which@2.0.2:
@@ -1673,7 +1702,7 @@ packages:
   /xss@0.0.9:
     resolution: {integrity: sha512-jPFdM56EihzKcXeGjFy0kxYigtdB1CWCzS3FVp+HYv5a+BwSHpBe+FQOVgaVN1qQ81h8/W0ICj/4/sVRb8eZWQ==}
     engines: {node: '>= 0.6.0'}
-    dev: false
+    dev: true
 
   /y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}

--- a/src/NiivueMutator.ts
+++ b/src/NiivueMutator.ts
@@ -1,0 +1,279 @@
+import { Niivue, NVImage } from "@niivue/niivue";
+import {
+  NVRVolume,
+  LoadableVolumeOptions,
+  ImageOptions,
+  NVROptions,
+  NVRMesh,
+  HasUrlObject,
+} from "./model.ts";
+import * as setters from "./setters.ts";
+
+/**
+ * Provides helper functions to mutate the Niivue instance.
+ */
+class NiivueMutator {
+  private readonly nv: Niivue;
+  private readonly volumeUpdateFunctionByIndexMap: setters.VolumeUpdateFunctionByIndexMap;
+  private readonly volumeUpdateFunctionByIdMap: setters.VolumeUpdateFunctionByIdMap;
+  private readonly optionUpdateFunctionMap: setters.OptionUpdateFunctionMap;
+
+  constructor(nv: Niivue) {
+    this.nv = nv;
+    this.volumeUpdateFunctionByIndexMap =
+      setters.volumeUpdateFunctionByIndexMap(nv);
+    this.volumeUpdateFunctionByIdMap = setters.volumeUpdateFunctionByIdMap(nv);
+    this.optionUpdateFunctionMap = setters.optionUpdateFunctionMap(nv);
+  }
+
+  /**
+   * Check whether the WebGL context is ready. This method must return `true` before
+   * any other method of this object is called.
+   */
+  public glIsReady(): boolean {
+    try {
+      return !!this.nv.gl;
+    } catch (_e: any) {
+      return false;
+    }
+  }
+
+  /**
+   * Change Niivue options.
+   */
+  public applyOptions(options: NVROptions) {
+    let needGLVolumeUpdate = false;
+    Object.entries(options)
+      // some TypeScript BS
+      .map(<T>([k, v]: [string, T]): [keyof NVROptions, T] => [
+        k as keyof NVROptions,
+        v,
+      ])
+      .forEach(([key, value]) => {
+        /*
+         * Some options have setter methods, some options don't.
+         *
+         * 1. If a setter method is known, then use the setter method.
+         * 2. If a property can be set on nv.opts.*, set that, then call nv.updateGLVolume()
+         * 3. If a property can be set on nv.*, set that, then call nv.updateGLVolume()
+         */
+        const setter = this.optionUpdateFunctionMap[key];
+        if (setter !== undefined) {
+          setter(value);
+        } else if (key in this.nv.opts) {
+          // @ts-ignore
+          this.nv.opts[key] = value;
+          needGLVolumeUpdate = true;
+        } else if (key in this.nv) {
+          // @ts-ignore
+          this.nv[key] = value;
+          needGLVolumeUpdate = true;
+        } else {
+          console.warn(
+            `Don't know how to handle ${key}=${JSON.stringify(value)}`,
+          );
+        }
+      });
+    if (needGLVolumeUpdate) {
+      this.nv.updateGLVolume();
+    }
+  }
+
+  /**
+   * A wrapper for `Niivue.loadVolumes` which also handles bugs.
+   * N.B.: `Niivue.loadVolumes` will _clear_ any currently loaded volume,
+   * so to add new volumes it is necessary to pass old volumes as well.
+   */
+  public async loadVolumes(volumes: NVRVolume[]) {
+    await this.nv.loadVolumes(volumes.map(toLoadableVolume));
+    volumes.forEach((volume) => this.handleSpecialImageProperties(volume));
+    this.workaroundLoadVolumesColorbarBug(volumes);
+  }
+
+  /**
+   * Workaround for upstream bug https://github.com/niivue/niivue/issues/848
+   *
+   * `colorbarVisible` is a key of `ImageFromUrlOptions` but it is not respected by `nv.loadVolumes`
+   */
+  private workaroundLoadVolumesColorbarBug(volumes: NVRVolume[]) {
+    const needToSetColorbarVisible = volumes.filter(
+      (v): v is { colorbarVisible: boolean; url: string } =>
+        "colorbarVisible" in v,
+    );
+    if (needToSetColorbarVisible.length > 0) {
+      needToSetColorbarVisible.forEach(
+        (vol, i) => (this.nv.volumes[i].colorbarVisible = vol.colorbarVisible),
+      );
+      this.nv.updateGLVolume();
+    }
+  }
+
+  /**
+   * Handle special properties such as the keys of `SpecialVolumeOptions`.
+   */
+  private handleSpecialImageProperties(volume: NVRVolume) {
+    if ("modulationImageUrl" in volume) {
+      this.setModulationImage(volume, volume.modulationImageUrl);
+    }
+  }
+
+  /**
+   * Wrapper for `this.nv.setModulationImage`
+   */
+  private setModulationImage(
+    target: NVRVolume,
+    modulateUrl: string | null | undefined,
+  ) {
+    const targetImage = this.nv.getMediaByUrl(target.url) as NVImage;
+    if (modulateUrl === null || modulateUrl === undefined) {
+      // upstream bug: parameter of setModulationImage should be nullable
+      // https://github.com/niivue/niivue/pull/859
+      this.nv.setModulationImage(
+        targetImage.id,
+        // @ts-ignore
+        null,
+        target.modulateAlpha || 0,
+      );
+      return;
+    }
+    const modulationImage = this.nv.getMediaByUrl(modulateUrl);
+    if (modulationImage === undefined) {
+      console.warn(`modulationImageUrl not found in volumes: ${modulateUrl}`);
+      return;
+    }
+    this.nv.setModulationImage(
+      targetImage.id,
+      modulationImage.id,
+      target.modulateAlpha || 0,
+    );
+  }
+
+  /**
+   * Apply changes to already loaded volumes.
+   */
+  public applyVolumeChanges(changes: NVRVolume) {
+    this.applyImageSettableChanges(changes);
+    this.handleSpecialImageProperties(changes);
+  }
+
+  /**
+   * Apply whatever properties of `nv.volumes[*]` which can be set directly on an `NVImage`.
+   */
+  private applyImageSettableChanges(changes: NVRVolume) {
+    const volumeIndex = this.getVolumeIndex(changes);
+    typedEntries(changes).forEach(([propertyName, value]) => {
+      if (!isVolumeOption(propertyName)) {
+        return;
+      }
+      /*
+       * There are 3 ways a property can be set in Niivue:
+       *
+       * 1. a setter function which takes in an index (number)
+       * 2. a setter function which takes in an id (string)
+       * 3. no setter function given, must set property then call nv.updateGLVolume()
+       */
+      const setters: (() => (() => void) | null)[] = [
+        () => {
+          const setter = this.volumeUpdateFunctionByIndexMap[propertyName];
+          return setter ? () => setter(volumeIndex, value) : null;
+        },
+        () => {
+          const setter = this.volumeUpdateFunctionByIdMap[propertyName];
+          return setter
+            ? () => setter(this.nv.volumes[volumeIndex].id, value)
+            : null;
+        },
+        () => {
+          return () => {
+            // fallback: manually set volume property then update.
+            // https://github.com/niivue/niivue/blob/41b134123870fb0b69540a2d8155e75ec8e06339/demos/features/modulate.html#L50-L51
+            // @ts-ignore
+            this.nv.volumes[volumeIndex][propertyName] = value;
+            this.nv.updateGLVolume();
+          };
+        },
+      ];
+      for (const getSetter of setters) {
+        const setter = getSetter();
+        if (setter !== null) {
+          setter();
+          return;
+        }
+      }
+    });
+  }
+
+  private getVolumeIndex(volume: NVRVolume): number {
+    const loadedImage = this.nv.getMediaByUrl(volume.url);
+    const i = this.nv.volumes.findIndex((volume) => volume === loadedImage);
+    if (i === -1) {
+      throw new Error(`No volume found with URL ${volume.url}`);
+    }
+    return i;
+  }
+}
+
+/**
+ * Converts to `LoadFromUrlParams` (which is not exported by niivue).
+ */
+function canonicalizeNvrMesh(mesh: NVRMesh): HasUrlObject {
+  if (mesh.layers) {
+    return {
+      ...mesh,
+      layers: Object.values(mesh.layers),
+    };
+  }
+  return mesh;
+}
+
+/**
+ * Wrapper around `Object.entries` with safe type coercion of the keys to `keyof T`.
+ */
+function typedEntries<V, T extends { [key: string]: V }>(x: T): [keyof T, V][] {
+  return Object.entries(x).map(([k, v]) => [k as keyof T, v]);
+}
+
+/**
+ * Fields of `NVRVolume` which cannot be changed by setting them directly on `nv.volumes[i]`.
+ */
+const SPECIAL_IMAGE_FIELDS: (keyof NVRVolume)[] = ["url", "modulationImageUrl"];
+
+/**
+ * Fields of `NVRVolume` which are unsupported by `Niivue.loadVolumes`.
+ */
+const UNLOADABLE_IMAGE_FIELDS: (keyof NVRVolume)[] = [
+  "modulationImageUrl",
+  "modulateAlpha",
+];
+
+/**
+ * Helper function for filtering volume properties which can be set directly on `NVImage`.
+ */
+function isVolumeOption(name: keyof NVRVolume): name is keyof ImageOptions {
+  // does TypeScript have a "keyof" function which works in an if statement at runtime?
+  return SPECIAL_IMAGE_FIELDS.findIndex((key) => name === key) === -1;
+}
+
+/**
+ * Type for parameter supported by `Niivue.loadVolumes`.
+ * It's a subset of `ImageFromUrlOptions`, which is sadly a private type.
+ */
+type LoadableVolume = LoadableVolumeOptions & {
+  url: string;
+};
+
+/**
+ * If necessary, copies `volume` and deletes fields which are unsupported by `Niivue.loadVolumes`.
+ * This of course means that `Niivue.loadVolumes` might not complete the job.
+ */
+function toLoadableVolume(volume: NVRVolume): LoadableVolume {
+  const toRemove = UNLOADABLE_IMAGE_FIELDS.filter((name) => name in volume);
+  if (toRemove.length === 0) {
+    return volume;
+  }
+  const copy: NVRVolume = { ...volume };
+  toRemove.forEach((name) => delete copy[name]);
+  return copy;
+}
+
+export default NiivueMutator;

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,4 +1,4 @@
-import { SLICE_TYPE } from "@niivue/niivue";
+import { NiiVueOptions } from "./reexport.ts";
 
 type HasUrlObject = { [key: string]: any; url: string };
 
@@ -39,10 +39,12 @@ type NVRMesh = {
 };
 
 /**
- * A volume (e.g. t2 MRI) in NiiVue.
+ * Options of a volume which are directly compatible with `ImageFromUrlOptions` and `NVImage`, meaning:
+ *
+ * - properties are supported by `Niivue.loadVolumes`
+ * - properties can be changed by mutating `nv.volumes[*].*`
  */
-type NVRVolume = {
-  url: string;
+type LoadableVolumeOptions = {
   opacity?: number;
   colormap?: string;
   colormapNegative?: string;
@@ -51,50 +53,67 @@ type NVRVolume = {
   trustCalMinMax?: boolean;
   visible?: boolean;
   colorbarVisible?: boolean;
+};
 
+/**
+ * Options of a volume which are directly compatible with `NVImage`.
+ */
+type ImageOptions = LoadableVolumeOptions & {
+  modulateAlpha?: number;
+};
+
+/**
+ * Special options of a volume which are supported handled differently in `niivue-react` and Niivue,
+ * for the sake of ergonomics.
+ */
+type SpecialVolumeOptions = {
   /**
-   * Another loaded image which modulates this one.
+   * Another loaded image which modulates this one. See `Niivue.setModulationImage`
+   *
+   * https://github.com/niivue/niivue/blob/4dd7e2b946cdf384e88f76f61657a0ef1531f978/src/niivue/index.ts#L5893-L5914
    */
   modulationImageUrl?: string | null;
-  modulateAlpha?: number;
+};
+
+/**
+ * Volume options supported by `niivue-react`.
+ */
+type NVRVolumeOptions = ImageOptions & SpecialVolumeOptions;
+
+/**
+ * A volume (e.g. t2 MRI) in NiiVue.
+ */
+type NVRVolume = NVRVolumeOptions & {
+  url: string;
 };
 
 /**
  * Niivue configurations.
  *
- * This is a subset of what is configurable via `nv.opts` U `nv`.
- * There is some overlap with the options of
- * [`NiiVueOptions`](https://github.com/niivue/niivue/blob/41b134123870fb0b69540a2d8155e75ec8e06339/src/niivue/index.ts#L239-L242),
- * though some variable names are different.
+ * This is a union of [`NiivueOptions`](https://github.com/niivue/niivue/blob/9fa221344a6f39315574efa4ef4c6e9da930de57/src/niivue/index.ts#L241-L327)
+ * and a subset of the fields of [`Niivue`](https://github.com/niivue/niivue/blob/9fa221344a6f39315574efa4ef4c6e9da930de57/src/niivue/index.ts#L381-L441).
  */
-type NVROptions = {
-  // nv.opts.* fields
-  isColorbar?: boolean;
-  isOrientCube?: boolean;
-  isHighResolutionCapable?: boolean;
-  meshThicknessOn2D?: number;
-  sliceType?: SLICE_TYPE;
-  isSliceMM?: boolean;
-  backColor?: number[];
-  isNearestInterpolation?: boolean;
-  multiplanarForceRender?: boolean;
-  isRadiologicalConvention?: boolean;
+type NVROptions = NiiVueOptions & {
+  textHeight?: number;
+  colorbarHeight?: number;
+
   // nv.* fields
   overlayOutlineWidth?: number;
+
+  // not safe to configure by setting nv.opts.* directly, must use setter methods
+  crosshairColor?: number[];
+  crosshairWidth?: number;
+  volScaleMultiplier?: number;
 };
 
-/**
- * Converts to `LoadFromUrlParams` (which is not exported by niivue).
- */
-function canonicalizeNvrMesh(mesh: NVRMesh): HasUrlObject {
-  if (mesh.layers) {
-    return {
-      ...mesh,
-      layers: Object.values(mesh.layers),
-    };
-  }
-  return mesh;
-}
-
-export type { NVRMesh, NVRMeshLayer, NVRVolume, NVROptions, HasUrlObject };
-export { canonicalizeNvrMesh };
+export type {
+  NVRMesh,
+  NVRMeshLayer,
+  NVRVolume,
+  LoadableVolumeOptions,
+  ImageOptions,
+  SpecialVolumeOptions,
+  NVRVolumeOptions,
+  NVROptions,
+  HasUrlObject,
+};

--- a/src/reexport.ts
+++ b/src/reexport.ts
@@ -1,0 +1,97 @@
+/**
+ * Type definitions copy-pasted from `niivue` since they are not public.
+ */
+
+import { DRAG_MODE } from "@niivue/niivue";
+
+/**
+ * Niivue options.
+ *
+ * https://github.com/niivue/niivue/blob/4dd7e2b946cdf384e88f76f61657a0ef1531f978/src/niivue/index.ts#L241-L327
+ */
+type NiiVueOptions = {
+  // the text height for orientation labels (0 to 1). Zero for no text labels
+  textHeight?: number;
+  // size of colorbar. 0 for no colorbars, fraction of Nifti j dimension
+  colorbarHeight?: number;
+  // padding around colorbar when displayed
+  colorbarMargin?: number;
+  // crosshair size. Zero for no crosshair
+  crosshairWidth?: number;
+  // ruler size. Zero (or isRuler is false) for no ruler
+  rulerWidth?: number;
+  // the background color. RGBA values from 0 to 1. Default is black
+  backColor?: number[];
+  // the crosshair color. RGBA values from 0 to 1. Default is red
+  crosshairColor?: number[];
+  // the font color. RGBA values from 0 to 1. Default is gray
+  fontColor?: number[];
+  // the selection box color when the intensty selection box is shown (right click and drag). RGBA values from 0 to 1. Default is transparent white
+  selectionBoxColor?: number[];
+  // the color of the visible clip plane. RGBA values from 0 to 1. Default is white
+  clipPlaneColor?: number[];
+  // the color of the ruler. RGBA values from 0 to 1. Default is translucent red
+  rulerColor?: number[];
+  // true/false whether crosshairs are shown on 3D rendering
+  show3Dcrosshair?: boolean;
+  // whether to trust the nifti header values for cal_min and cal_max. Trusting them results in faster loading because we skip computing these values from the data
+  trustCalMinMax?: boolean;
+  // the keyboard key used to cycle through clip plane orientations. The default is "c"
+  clipPlaneHotKey?: string;
+  // the keyboard key used to cycle through view modes. The default is "v"
+  viewModeHotKey?: string;
+  // the keyUp debounce time in milliseconds. The default is 50 ms. You must wait this long before a new hot-key keystroke will be registered by the event listener
+  keyDebounceTime?: number;
+  // the maximum time in milliseconds for a double touch to be detected. The default is 500 ms
+  doubleTouchTimeout?: number;
+  // the minimum time in milliseconds for a touch to count as long touch. The default is 1000 ms
+  longTouchTimeout?: number;
+  // whether or not to use radiological convention in the display
+  isRadiologicalConvention?: boolean;
+  // set the logging level to one of: debug, info, warn, error, fatal, silent
+  logLevel?: "debug" | "info" | "warn" | "error" | "fatal" | "silent";
+  // the loading text to display when there is a blank canvas and no images
+  loadingText?: string;
+  // whether or not to allow file and url drag and drop on the canvas
+  dragAndDropEnabled?: boolean;
+  // whether nearest neighbor interpolation is used, else linear interpolation
+  isNearestInterpolation?: boolean;
+  // whether atlas maps are only visible at the boundary of regions
+  isAtlasOutline?: boolean;
+  // whether a 10cm ruler is displayed
+  isRuler?: boolean;
+  // whether colorbar(s) are shown illustrating values for color maps
+  isColorbar?: boolean;
+  // whether orientation cube is shown for 3D renderings
+  isOrientCube?: boolean;
+  // spacing between tiles of a multiplanar view
+  multiplanarPadPixels?: number;
+  // always show rendering in multiplanar view
+  multiplanarForceRender?: boolean;
+  // 2D slice views can show meshes within this range. Meshes only visible in sliceMM (world space) mode
+  meshThicknessOn2D?: number;
+  // behavior for dragging (none, contrast, measurement, pan)
+  dragMode?: DRAG_MODE;
+  // when both voxel-based image and mesh is loaded, will depth picking be able to detect mesh or only voxels
+  isDepthPickMesh?: boolean;
+  // should slice text be shown in the upper right corner instead of the center of left and top axes?
+  isCornerOrientationText?: boolean;
+  // should 2D sagittal slices show the anterior direction toward the left or right?
+  sagittalNoseLeft?: boolean;
+  // are images aligned to voxel space (false) or world space (true)
+  isSliceMM?: boolean;
+  // demand that high-dot-per-inch displays use native voxel size
+  isHighResolutionCapable?: boolean;
+  // allow user to create and edit voxel-based drawings
+  drawingEnabled?: boolean;
+  // color of drawing when user drags mouse (if drawingEnabled)
+  penValue?: number;
+  // does a voxel have 6 (face), 18 (edge) or 26 (corner) neighbors?
+  floodFillNeighbors?: number;
+  // number of possible undo steps (if drawingEnabled)
+  maxDrawUndoBitmaps?: number;
+  // optional 2D png bitmap that can be rapidly loaded to defer slow loading of 3D image
+  thumbnail?: string;
+};
+
+export type { NiiVueOptions };

--- a/src/setters.ts
+++ b/src/setters.ts
@@ -1,0 +1,69 @@
+/**
+ * Helper functions for associating property names to setter methods.
+ */
+import { NVROptions, ImageOptions } from "./model.ts";
+import { Niivue } from "@niivue/niivue";
+
+type OptionUpdateFunctionMap = {
+  [key in keyof NVROptions]: (value: any) => void;
+};
+
+/**
+ * Creates associations between property names and Niivue setter methods.
+ */
+function optionUpdateFunctionMap(nv: Niivue): OptionUpdateFunctionMap {
+  const mapping = {
+    crosshairWidth: nv.setCrosshairWidth,
+    crosshairColor: nv.setCrosshairColor,
+  };
+  return bindAllValues(nv, mapping);
+}
+
+type VolumeUpdateFunctionByIndexMap = {
+  [key in keyof ImageOptions]: (index: number, value: any) => void;
+};
+
+/**
+ * Creates associations between volume property names and Niivue setter methods
+ * which identify volumes by list index number.
+ */
+function volumeUpdateFunctionByIndexMap(
+  nv: Niivue,
+): VolumeUpdateFunctionByIndexMap {
+  const mapping = {
+    opacity: nv.setOpacity,
+  };
+  return bindAllValues(nv, mapping);
+}
+
+type VolumeUpdateFunctionByIdMap = {
+  [key in keyof ImageOptions]: (id: string, value: any) => void;
+};
+
+/**
+ * Creates associations between volume property names and Niivue setter methods
+ * which identify volumes by volume UUID string.
+ */
+function volumeUpdateFunctionByIdMap(nv: Niivue): VolumeUpdateFunctionByIdMap {
+  const mapping = {
+    colormap: nv.setColormap,
+    colormapNegative: nv.setColormapNegative,
+  };
+  return bindAllValues(nv, mapping);
+}
+
+function bindAllValues<N, M extends object>(nv: N, mapping: M): M {
+  const binded = Object.entries(mapping).map(([k, v]) => [k, v.bind(nv)]);
+  return Object.fromEntries(binded);
+}
+
+export type {
+  OptionUpdateFunctionMap,
+  VolumeUpdateFunctionByIndexMap,
+  VolumeUpdateFunctionByIdMap,
+};
+export {
+  optionUpdateFunctionMap,
+  volumeUpdateFunctionByIndexMap,
+  volumeUpdateFunctionByIdMap,
+};

--- a/tests/NiivueMutator.test.ts
+++ b/tests/NiivueMutator.test.ts
@@ -18,7 +18,12 @@ it("uses option setter functions", () => {
     .mockImplementationOnce(noop);
   const setCrosshairColor = vi
     .spyOn(nv, "setCrosshairColor")
-    .mockImplementationOnce(noop);
+    .mockImplementationOnce(
+      // upstream bug: not actually async
+      // https://github.com/niivue/niivue/pull/858
+      // @ts-ignore
+      noop,
+    );
   const updateGLVolume = vi
     .spyOn(nv, "updateGLVolume")
     .mockImplementationOnce(noop);
@@ -71,8 +76,8 @@ it("warns about bogus options", () => {
   const nvMutator = new NiivueMutator(nv);
   const consoleMock = vi.spyOn(console, "warn").mockImplementation(noop);
 
-  // @ts-ignore
   nvMutator.applyOptions({
+    // @ts-ignore
     bogusOption: "whale whale whale, what do we have here",
   });
 
@@ -324,10 +329,9 @@ it("uses volume property setter methods", async () => {
   vi.spyOn(nv, "volumes", "get").mockReturnValue(
     Object.values(nvVolumes) as NVImage[],
   );
-  vi.spyOn(nv, "updateGLVolume")
-    .mockImplementationOnce(noop);
-  const setOpacity = vi.spyOn(nv, 'setOpacity').mockImplementation(noop);
-  const setColormap = vi.spyOn(nv, 'setColormap').mockImplementation(noop);
+  vi.spyOn(nv, "updateGLVolume").mockImplementationOnce(noop);
+  const setOpacity = vi.spyOn(nv, "setOpacity").mockImplementation(noop);
+  const setColormap = vi.spyOn(nv, "setColormap").mockImplementation(noop);
 
   const nvMutator = new NiivueMutator(nv);
   await nvMutator.loadVolumes(volumes);
@@ -338,7 +342,7 @@ it("uses volume property setter methods", async () => {
   });
   expect(setColormap).toHaveBeenCalledOnce();
   expect(setColormap).toHaveBeenCalledWith("cope1-uuid", "blue");
-  expect(nv.updateGLVolume).not.toHaveBeenCalled();  // not called bc the mock is a no-op
+  expect(nv.updateGLVolume).not.toHaveBeenCalled(); // not called bc the mock is a no-op
 
   nvMutator.applyVolumeChanges({
     url: "https://example.com/images/mean_func.nii.gz",
@@ -346,7 +350,7 @@ it("uses volume property setter methods", async () => {
   });
   expect(setOpacity).toHaveBeenCalledOnce();
   expect(setOpacity).toHaveBeenCalledWith(0, 0.7);
-  expect(nv.updateGLVolume).not.toHaveBeenCalled();  // not called bc the mock is a no-op
+  expect(nv.updateGLVolume).not.toHaveBeenCalled(); // not called bc the mock is a no-op
 });
 
 function noop() {}

--- a/tests/NiivueMutator.test.ts
+++ b/tests/NiivueMutator.test.ts
@@ -1,0 +1,354 @@
+import { expect, it, vi } from "vitest";
+import { DRAG_MODE, Niivue, NVImage } from "@niivue/niivue";
+import NiivueMutator from "../src/NiivueMutator.ts";
+
+it("reports GL context is ready", () => {
+  const nv = new Niivue();
+  const nvMutator = new NiivueMutator(nv);
+  expect(nvMutator.glIsReady()).toBe(false);
+  // @ts-ignore
+  vi.spyOn(nv, "gl", "get").mockReturnValue("fake WebGL2RenderingContext");
+  expect(nvMutator.glIsReady()).toBe(true);
+});
+
+it("uses option setter functions", () => {
+  const nv = new Niivue();
+  const setCrosshairWidth = vi
+    .spyOn(nv, "setCrosshairWidth")
+    .mockImplementationOnce(noop);
+  const setCrosshairColor = vi
+    .spyOn(nv, "setCrosshairColor")
+    .mockImplementationOnce(noop);
+  const updateGLVolume = vi
+    .spyOn(nv, "updateGLVolume")
+    .mockImplementationOnce(noop);
+  const nvMutator = new NiivueMutator(nv);
+
+  nvMutator.applyOptions({ crosshairWidth: 5 });
+  expect(setCrosshairWidth).toHaveBeenCalledOnce();
+  expect(setCrosshairWidth).toHaveBeenLastCalledWith(5);
+  expect(setCrosshairColor).not.toHaveBeenCalled();
+  expect(updateGLVolume).not.toHaveBeenCalled();
+  setCrosshairWidth.mockReset();
+
+  const color = [255, 0, 0];
+  nvMutator.applyOptions({ crosshairColor: color });
+  expect(setCrosshairColor).toHaveBeenCalledOnce();
+  expect(setCrosshairColor).toHaveBeenCalledWith(color);
+  expect(setCrosshairWidth).not.toHaveBeenCalled();
+  expect(updateGLVolume).not.toHaveBeenCalled();
+  setCrosshairColor.mockReset();
+
+  expect(nv.opts.isRadiologicalConvention).toBe(false);
+  expect(nv.opts.dragMode).toBe(DRAG_MODE.contrast);
+  nvMutator.applyOptions({
+    isRadiologicalConvention: true,
+    dragMode: DRAG_MODE.measurement,
+  });
+  expect(nv.opts.isRadiologicalConvention).toBe(true);
+  expect(nv.opts.dragMode).toBe(DRAG_MODE.measurement);
+  expect(updateGLVolume).toHaveBeenCalledOnce();
+  expect(setCrosshairWidth).not.toHaveBeenCalled();
+  updateGLVolume.mockReset();
+
+  expect(nv.opts.isOrientCube).toBe(false);
+  nvMutator.applyOptions({
+    loadingText: "I've got nothing",
+    isOrientCube: true,
+    overlayOutlineWidth: 10,
+    crosshairWidth: 2,
+  });
+  expect(setCrosshairWidth).toHaveBeenCalledOnce();
+  expect(setCrosshairWidth).toHaveBeenLastCalledWith(2);
+  expect(nv.opts.loadingText).toBe("I've got nothing");
+  expect(nv.opts.isOrientCube).toBe(true);
+  expect(nv.overlayOutlineWidth).toBe(10);
+  expect(updateGLVolume).toHaveBeenCalledOnce();
+});
+
+it("warns about bogus options", () => {
+  const nv = new Niivue();
+  const nvMutator = new NiivueMutator(nv);
+  const consoleMock = vi.spyOn(console, "warn").mockImplementation(noop);
+
+  // @ts-ignore
+  nvMutator.applyOptions({
+    bogusOption: "whale whale whale, what do we have here",
+  });
+
+  expect(consoleMock).toHaveBeenCalledOnce();
+  expect(consoleMock).toHaveBeenCalledWith(
+    'Don\'t know how to handle bogusOption="whale whale whale, what do we have here"',
+  );
+});
+
+it("can load volumes", async () => {
+  const nv = new Niivue();
+  const loadVolumes = vi
+    .spyOn(nv, "loadVolumes")
+    .mockImplementation(async () => nv);
+  const nvMutator = new NiivueMutator(nv);
+
+  const volumes = [
+    {
+      url: "https://example.com/ventricles.nii.gz",
+      opacity: 0.5,
+    },
+    {
+      url: "https://example.com/brain.nii.gz",
+    },
+  ];
+
+  await nvMutator.loadVolumes(volumes);
+  expect(loadVolumes).toHaveBeenCalledOnce();
+  expect(loadVolumes.mock.lastCall).toStrictEqual([volumes]);
+});
+
+it("can load volumes with modulation image", async () => {
+  const volumes = [
+    {
+      url: "https://example.com/images/mean_func.nii.gz",
+      opacity: 1,
+      colormap: "gray",
+    },
+    {
+      url: "https://example.com/images/cope1.nii.gz",
+      colormap: "winter",
+      opacity: 1,
+      cal_min: 0.0,
+      cal_max: 100,
+      modulationImageUrl: "https://example.com/images/tstat1.nii.gz",
+      modulateAlpha: 1,
+    },
+    {
+      url: "https://example.com/images/tstat1.nii.gz",
+      opacity: 0,
+      colormap: "warm",
+      cal_min: 0,
+      cal_max: 4.5,
+    },
+  ];
+
+  const volumesWithoutModulationFields = [
+    {
+      url: "https://example.com/images/mean_func.nii.gz",
+      opacity: 1,
+      colormap: "gray",
+    },
+    {
+      url: "https://example.com/images/cope1.nii.gz",
+      colormap: "winter",
+      opacity: 1,
+      cal_min: 0.0,
+      cal_max: 100,
+    },
+    {
+      url: "https://example.com/images/tstat1.nii.gz",
+      opacity: 0,
+      colormap: "warm",
+      cal_min: 0,
+      cal_max: 4.5,
+    },
+  ];
+  const nvVolumes: { [key: string]: { id: string } } = {
+    "https://example.com/images/mean_func.nii.gz": {
+      id: "mean_func-uuid",
+    },
+    "https://example.com/images/tstat1.nii.gz": {
+      id: "tstat1-uuid",
+    },
+    "https://example.com/images/cope1.nii.gz": {
+      id: "cope1-uuid",
+    },
+  };
+
+  const nv = new Niivue();
+  const loadVolumes = vi
+    .spyOn(nv, "loadVolumes")
+    .mockImplementation(async () => nv);
+  const setModulationImage = vi
+    .spyOn(nv, "setModulationImage")
+    .mockImplementation(noop);
+  vi.spyOn(nv, "volumes", "get").mockReturnValue(
+    Object.values(nvVolumes) as NVImage[],
+  );
+  vi.spyOn(nv, "getMediaByUrl").mockImplementation((url) => {
+    return nvVolumes[url] as NVImage;
+  });
+  vi.spyOn(nv, "updateGLVolume").mockImplementation(noop);
+  const nvMutator = new NiivueMutator(nv);
+
+  await nvMutator.loadVolumes(volumes);
+  expect(loadVolumes).toHaveBeenCalledOnce();
+  expect(loadVolumes.mock.lastCall).toStrictEqual([
+    volumesWithoutModulationFields,
+  ]);
+  expect(setModulationImage).toHaveBeenCalledOnce();
+  expect(setModulationImage).toHaveBeenCalledWith(
+    "cope1-uuid",
+    "tstat1-uuid",
+    1,
+  );
+  setModulationImage.mockReset();
+
+  nvMutator.applyVolumeChanges({
+    url: "https://example.com/images/cope1.nii.gz",
+    cal_max: 70,
+    modulationImageUrl: null,
+  });
+  expect(setModulationImage).toHaveBeenCalledOnce();
+  expect(setModulationImage).toHaveBeenCalledWith("cope1-uuid", null, 0);
+  expect(nv.volumes[2].cal_max).toBe(70);
+});
+
+it("warns if modulationImageUrl does not refer to a valid volume", async () => {
+  const volumes = [
+    {
+      url: "https://example.com/images/mean_func.nii.gz",
+      opacity: 1,
+      colormap: "gray",
+    },
+    {
+      url: "https://example.com/images/cope1.nii.gz",
+      colormap: "winter",
+      opacity: 1,
+      cal_min: 0.0,
+      cal_max: 100,
+      modulationImageUrl: "https://example.com/images/tstat1.nii.gz",
+      modulateAlpha: 1,
+    },
+  ];
+  const nvVolumes: { [key: string]: { id: string } } = {
+    "https://example.com/images/mean_func.nii.gz": {
+      id: "mean_func-uuid",
+    },
+    "https://example.com/images/cope1.nii.gz": {
+      id: "cope1-uuid",
+    },
+  };
+
+  const nv = new Niivue();
+  const loadVolumes = vi
+    .spyOn(nv, "loadVolumes")
+    .mockImplementation(async () => nv);
+  const setModulationImage = vi
+    .spyOn(nv, "setModulationImage")
+    .mockImplementation(noop);
+  vi.spyOn(nv, "getMediaByUrl").mockImplementation((url) => {
+    return nvVolumes[url] as NVImage;
+  });
+  const consoleMock = vi.spyOn(console, "warn").mockImplementation(noop);
+  const nvMutator = new NiivueMutator(nv);
+
+  await nvMutator.loadVolumes(volumes);
+  expect(loadVolumes).toHaveBeenCalledOnce();
+  expect(setModulationImage).not.toHaveBeenCalledOnce();
+  expect(consoleMock).toHaveBeenCalledOnce();
+  expect(consoleMock).toHaveBeenCalledWith(
+    "modulationImageUrl not found in volumes: https://example.com/images/tstat1.nii.gz",
+  );
+});
+
+it("errors if changing a volume which is not loaded", async () => {
+  const volumes = [
+    {
+      url: "https://example.com/images/mean_func.nii.gz",
+    },
+    {
+      url: "https://example.com/images/cope1.nii.gz",
+    },
+  ];
+  const nvVolumes: { [key: string]: { id: string } } = {
+    "https://example.com/images/mean_func.nii.gz": {
+      id: "mean_func-uuid",
+    },
+    "https://example.com/images/cope1.nii.gz": {
+      id: "cope1-uuid",
+    },
+  };
+
+  const nv = new Niivue();
+  vi.spyOn(nv, "loadVolumes").mockImplementation(async () => nv);
+  vi.spyOn(nv, "getMediaByUrl").mockImplementation((url) => {
+    return nvVolumes[url] as NVImage;
+  });
+  vi.spyOn(nv, "volumes", "get").mockReturnValue(
+    Object.values(nvVolumes) as NVImage[],
+  );
+  const updateGLVolume = vi
+    .spyOn(nv, "updateGLVolume")
+    .mockImplementationOnce(noop);
+  const nvMutator = new NiivueMutator(nv);
+
+  await nvMutator.loadVolumes(volumes);
+  nvMutator.applyVolumeChanges({
+    url: "https://example.com/images/mean_func.nii.gz",
+    cal_max: 50,
+  });
+  expect(updateGLVolume).toHaveBeenCalledOnce();
+  expect(nv.volumes[0].cal_max).toBe(50);
+
+  expect(() => {
+    nvMutator.applyVolumeChanges({
+      url: "https://example.com/notloaded.nii.gz",
+      cal_max: 50,
+    });
+  }).toThrowError(
+    "No volume found with URL https://example.com/notloaded.nii.gz",
+  );
+});
+
+it("uses volume property setter methods", async () => {
+  const volumes = [
+    {
+      url: "https://example.com/images/mean_func.nii.gz",
+    },
+    {
+      url: "https://example.com/images/cope1.nii.gz",
+    },
+  ];
+  const nvVolumes: { [key: string]: { id: string } } = {
+    "https://example.com/images/mean_func.nii.gz": {
+      id: "mean_func-uuid",
+    },
+    "https://example.com/images/cope1.nii.gz": {
+      id: "cope1-uuid",
+    },
+  };
+
+  const nv = new Niivue();
+  vi.spyOn(nv, "loadVolumes").mockImplementation(async () => nv);
+  vi.spyOn(nv, "getMediaByUrl").mockImplementation((url) => {
+    return nvVolumes[url] as NVImage;
+  });
+  vi.spyOn(nv, "volumes", "get").mockReturnValue(
+    Object.values(nvVolumes) as NVImage[],
+  );
+  vi.spyOn(nv, "updateGLVolume")
+    .mockImplementationOnce(noop);
+  const setOpacity = vi.spyOn(nv, 'setOpacity').mockImplementation(noop);
+  const setColormap = vi.spyOn(nv, 'setColormap').mockImplementation(noop);
+
+  const nvMutator = new NiivueMutator(nv);
+  await nvMutator.loadVolumes(volumes);
+
+  nvMutator.applyVolumeChanges({
+    url: "https://example.com/images/cope1.nii.gz",
+    colormap: "blue",
+  });
+  expect(setColormap).toHaveBeenCalledOnce();
+  expect(setColormap).toHaveBeenCalledWith("cope1-uuid", "blue");
+  expect(nv.updateGLVolume).not.toHaveBeenCalled();  // not called bc the mock is a no-op
+
+  nvMutator.applyVolumeChanges({
+    url: "https://example.com/images/mean_func.nii.gz",
+    opacity: 0.7,
+  });
+  expect(setOpacity).toHaveBeenCalledOnce();
+  expect(setOpacity).toHaveBeenCalledWith(0, 0.7);
+  expect(nv.updateGLVolume).not.toHaveBeenCalled();  // not called bc the mock is a no-op
+});
+
+function noop() {}
+
+async function asyncNoop() {}

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -243,7 +243,7 @@ const COLORS = {
   Yellow: [255, 165, 0, 1.0],
 };
 
-const DIFF_PRIMITIVE_TEST_CASES = [
+const DIFF_PRIMITIVE_TEST_CASES: [object, object, object, string][] = [
   [{}, {}, {}, "empty"],
   [{ flavor: "salty" }, { flavor: "salty" }, {}, "no change"],
   [{ flavor: "salty" }, {}, { flavor: undefined }, 'deleted "flavor"'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,5 @@
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "allowJs": true,
-    "types": [
-      "bun-types" // add Bun global
-    ]
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,5 +8,7 @@ export default defineConfig({
       include: ["src/**"],
       reportsDirectory: "./coverage-vitest",
     },
+    environment: 'happy-dom',
+    restoreMocks: true
   },
 });


### PR DESCRIPTION
Most mutable setter method calls on the Niivue object are moved from NiivueCanvas.tsx to a new file NiivueMutator.ts, which makes it possible to test those method calls using mocks and without React component testing.