### PR TITLE
feat: Allow Niivue context to be created without antialiasing

### DIFF
--- a/src/NiivueCanvas.tsx
+++ b/src/NiivueCanvas.tsx
@@ -48,7 +48,7 @@ const NiivueCanvas: React.FC<NiivueCanvasProps> = ({
   const prevOptionsRef = useRef<NVROptions>({});
 
   const setup = async (nv: Niivue) => {
-    await nv.attachToCanvas(canvasRef.current as HTMLCanvasElement);
+    await nv.attachToCanvas(canvasRef.current as HTMLCanvasElement, options?.isAntiAlias ?? null);
     onStart && onStart(nv);
   };
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -103,6 +103,9 @@ type NVROptions = NiiVueOptions & {
   crosshairColor?: number[];
   crosshairWidth?: number;
   volScaleMultiplier?: number;
+
+  // Sets the ant-alias option when attaching Niivue to canvas
+  isAntiAlias?: boolean;
 };
 
 export type {


### PR DESCRIPTION
Right now, antialiasing value is guessed based on CPU cores, however, one might want to disable it by default to improve performance.

https://github.com/niivue/niivue/issues/1187#issuecomment-2668889567